### PR TITLE
Rename MemberPage to MembershipPage

### DIFF
--- a/lib/membership_page.rb
+++ b/lib/membership_page.rb
@@ -2,7 +2,7 @@
 
 require 'scraped'
 
-class MemberPage < Scraped::HTML
+class MembershipPage < Scraped::HTML
   decorator Scraped::Response::Decorator::CleanUrls
 
   field :term do

--- a/test/data/abril-martorell-fernando.yml
+++ b/test/data/abril-martorell-fernando.yml
@@ -1,4 +1,4 @@
-:class: MemberPage
+:class: MembershipPage
 :url: http://www.congreso.es/portal/page/portal/Congreso/Congreso/Diputados/BusqForm?next_page=/wc/fichaDiputado&idDiputado=25&idLegislatura=1
 :to_h:
   :term: '1'

--- a/test/data/marcello-santos-ana.yml
+++ b/test/data/marcello-santos-ana.yml
@@ -1,4 +1,4 @@
-:class: MemberPage
+:class: MembershipPage
 :url: http://www.congreso.es/portal/page/portal/Congreso/Congreso/Diputados/BusqForm?next_page=/wc/fichaDiputado&idDiputado=338&idLegislatura=12
 :to_h:
   :term: '12'


### PR DESCRIPTION
Calling this class `MemberPage` wasn't accurate because this site has multiple different pages for each _member_, one for each membership they've held in a term.

Renaming this to `MembershipPage` will hopefully make it a bit clearer that each member has multiple memberships that need to be scraped individually.