### PR TITLE
Update to latest `scraper_test`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 
 GIT
   remote: https://github.com/everypolitician/scraper_test.git
-  revision: a217cbd51d0544261c059f877628ed384b8844ac
+  revision: 9e12a20f8f9a87aa1814dac210d70e51f7ad03b7
   specs:
     scraper_test (0.1.0)
       minitest

--- a/Rakefile
+++ b/Rakefile
@@ -5,4 +5,4 @@ RuboCop::RakeTask.new
 require 'scraper_test'
 ScraperTest::RakeTask.new.install_tasks
 
-task default: %w(rubocop test)
+task default: %w(rubocop test:data)


### PR DESCRIPTION
Update to the latest version of `scraper_test`, which changes the task from `rake test` to `rake test:data` (https://github.com/everypolitician/scraper_test/pull/83). 